### PR TITLE
Debug the next button & class active statement

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ exports.createPagination = function (pagination, options) {
 
     while (i < limit && i < pageCount) {
         n = start;
-        if (start === page) {
+        if (start == page) {
             template = template + '<li class="active"><a href="?page=' + n + '">' + n + '</a></li>';
         } else {
             template = template + '<li><a href="?page=' + n + '">' + n + '</a></li>';
@@ -58,12 +58,12 @@ exports.createPagination = function (pagination, options) {
     }
 
 // ========== Next Buton ===========
-    if (page === pageCount) {
+    if (page == pageCount) {
         n = pageCount;
         template = template + '<li class="disabled"><a href="?page=' + n + '">'+ rightText +'</i></a></li>';
     }
     else {
-        n = page + 1;
+        n = parseFloat(page) + 1;
         template = template + '<li><a href="?page=' + n + '">'+ rightText +'</a></li>';
     }
     template = template + '</ul>';


### PR DESCRIPTION
`parseFloat()` on line 66 was left out which means `n` was equal to 21 > 211 > 2111 instead of 3 > 4 > 5. I also use "==" for more flexibility (no needs to check if vars are absolutely numbers, which cause many bugs when they are string instead)
